### PR TITLE
Add neutral-density

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -74,6 +74,7 @@ A collaborative effort to organize Python tools for the Oceanographic Community
 - [cbsyst](https://pypi.org/project/cbsyst): Python module for calculating carbon and boron solution chem.
 - [mixsea](https://mixsea.readthedocs.io/en/v0.1.1/): Ocean mixing parameterizations in python.
 - [narwhal](https://github.com/njwilson23/narwhal): Experimental tools to organize, analyze, and plot CTD data, including GSW wrappers.
+- [neutral-density](https://github.com/d-sandborn/neutral-density): A direct translation of Jackett’s neutral density Fortran suite into Python. 
 - [PyCO2SYS](https://pyco2sys.readthedocs.io/en/latest/): Marine carbonate system calculations (translated and expanded from CO2SYS for MATLAB/Excel).
 - [pygsw](https://pypi.python.org/pypi/pygsw): C-wrapped alternative to python-gsw.
 - [python-ctd](https://pypi.python.org/pypi/ctd): Tools to load hydrographic data as pandas DataFrame with some handy methods for data pre-processing and analysis.


### PR DESCRIPTION
Added a link to the Github repo detailing my neutral-density Python package, which offers a (unique to my knowledge) option for calculating the neutral density oceanographic variable from hydrographic data within the Python ecosystem. 